### PR TITLE
Fix cleanup_webhooks.js

### DIFF
--- a/utils/cleanup_webhooks.js
+++ b/utils/cleanup_webhooks.js
@@ -15,7 +15,7 @@ hipchatter.webhooks(settings.test_room, function(err, response){
     for (var i=0; i<webhooks.length; i++){
         var url = webhooks[i].links.self+'?auth_token='+settings.apikey;
         console.log(url);
-        needle.delete(url, function(e, r, b){
+        needle.delete(url, {}, function(e, r, b){
         });
     }
 });


### PR DESCRIPTION
Technically you have to pass options to needle.delete.  Otherwise, you aren't setting a callback, you are using a function as the options to delete().  Not that it really matters since you aren't doing anything in the function...
