### PR TITLE
Always return error messages when an error occured

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Usage
 
 - `<endpoint>` is the hipchatter function you are using.
 - `params` are the parameter required by the function
-- `err` will be true if there's an error, null if there's not
+- `err` error object if there is an error, null otherwise
 - `response` the direct response from the HipChat API (JSON)
 
 Documentation
@@ -213,7 +213,7 @@ Send a room notification.
     - **message_format** - html (default), text
     - **notify** (boolean) - false (default), true
 
-**Results:** `err`, `err_response`
+**Results:** `err`
 
 #### Usage
 ````javascript
@@ -240,7 +240,7 @@ Create a webhook for HipChat to ping when a certain event happens in a room.
         - Valid values: `room_message`, `room_notification`, `room_exit`, `room_enter`, `room_topic_change`
     - **name** - name for this webhook
 
-**Results:** `err`, `err_response`
+**Results:** `err`
 
 #### Usage
 ````javascript
@@ -288,10 +288,10 @@ Remove a webhook.
 
 **Parameters:**
 
-- `room` (string) — the room name or id
+- `room` (string) - the room name or id
 - `webhook_id` (string) - the id for the webhook that was returned from `create_webhook`
 
-**Results:** `err`, `err_response`
+**Results:** `err`
 
 #### Usage
 ````javascript
@@ -303,9 +303,9 @@ hipchatter.deleted_webhook('Hipchatter Room', '12345', function(err){
 ### hipchatter.delete\_all_webhooks
 A convenience function to delete all webhooks associated with a room.
 
-**Parameters:** `room` (string) — the room name or id
+**Parameters:** `room` (string) - the room name or id
 
-**Results:** `err`, `err_response`
+**Results:** `err`
 
 #### Usage
 ````javascript
@@ -319,10 +319,10 @@ Set the topic of a room.
 
 **Parameters:** 
 
-- `room` (string) — Required. The room name or id.
+- `room` (string) - Required. The room name or id.
 - `topic` (string) - Required. The topic that this room will be set to.
 
-**Results:** `err`, `err_response`
+**Results:** `err`
 
 #### Usage
 ````javascript

--- a/hipchatter.js
+++ b/hipchatter.js
@@ -135,19 +135,19 @@ Hipchatter.prototype = {
             this.request('post', 'room/'+room+'/notification', {message: message, token: token}, callback);
         }
         else if (typeof options != 'object' && typeof options == 'function') {
-            options(true, "Must supply an options object to the notify function containing at least the message and the room notification token. See https://www.hipchat.com/docs/apiv2/method/send_room_notification");
+            options(new Error('Must supply an options object to the notify function containing at least the message and the room notification token. See https://www.hipchat.com/docs/apiv2/method/send_room_notification'));
         }
         else if (!options.hasOwnProperty('message') || (!options.hasOwnProperty('token'))) {
-            callback(true, "Message and Room Notification token are required.");
+            callback(new Error('Message and Room Notification token are required.'));
         }
         else this.request('post', 'room/'+room+'/notification', options, callback);
     },
     create_webhook: function(room, options, callback){
         if (typeof options != 'object' && typeof options == 'function') {
-            options(true, "Must supply an options object to the notify function containing at least the message and the room notification token. See https://www.hipchat.com/docs/apiv2/method/send_room_notification");
+            options(new Error('Must supply an options object to the notify function containing at least the message and the room notification token. See https://www.hipchat.com/docs/apiv2/method/send_room_notification'));
         }
         else if (!options.hasOwnProperty('url') || (!options.hasOwnProperty('event'))) {
-            callback(true, "URL and Event are required.");
+            callback(new Error('URL and Event are required.'));
         }
         else this.request('post', 'room/'+room+'/webhook', options, callback);
     },
@@ -160,12 +160,12 @@ Hipchatter.prototype = {
     delete_webhook: function(room, id, callback){
         needle.delete(this.url('room/'+room+'/webhook/'+id), null, function (error, response, body) {
             // Connection error
-            if (!!error) callback(true, 'HipChat API Error.');
+            if (!!error) callback(new Error('HipChat API Error.'));
 
             // HipChat returned an error or no HTTP Success status code
             else if (body.hasOwnProperty('error') || response.statusCode < 200 || response.statusCode >= 300){
-                try { callback(true, body.error.message); }
-                catch (e) {callback(true, body); }
+                try { callback(new Error(body.error.message)); }
+                catch (e) {callback(new Error(body)); }
             }
 
             // Everything worked
@@ -177,7 +177,7 @@ Hipchatter.prototype = {
     delete_all_webhooks: function(room, callback){
         var self = this;
         this.webhooks(room, function(err, response){
-            if (err) return callback(true, response);
+            if (err) return callback(new Error(response));
             
             var hooks = response.items;
             var hookCalls = [];
@@ -249,12 +249,12 @@ Hipchatter.prototype = {
             if (DEBUG) {console.log('RESPONSE: ', error, response, body);}
 
             // Connection error
-            if (!!error) callback(true, 'HipChat API Error.');
+            if (!!error) callback(new Error('HipChat API Error.'));
 
             // HipChat returned an error or no HTTP Success status code
             else if (body.hasOwnProperty('error') || response.statusCode < 200 || response.statusCode >= 300){
-                try { callback(true, body.error.message); }
-                catch (e) {callback(true, body); }
+                try { callback(new Error(body.error.message)); }
+                catch (e) {callback(new Error(body)); }
             }
 
             // Everything worked
@@ -285,7 +285,7 @@ Hipchatter.prototype = {
 
         // otherwise, something went wrong   
         } else { 
-            callback(true, 'Invalid use of the hipchatter.request function.'); 
+            callback(new Error('Invalid use of the hipchatter.request function.'));
         }
     },
 

--- a/test/test.js
+++ b/test/test.js
@@ -107,9 +107,8 @@ describe('Endpoints', function(){
             expect(room.id).to.be.a.number;
         });
         it('should return an error if a room with the given name already exists', function(done){
-            hipchatter.create_room({name: 'Test Room'}, function(err, message){
-                expect(err).to.be.true;
-                expect(message).to.equal('Another room exists with that name.');
+            hipchatter.create_room({name: 'Test Room'}, function(err){
+                expect(err.message).to.equal('Another room exists with that name.');
 
                 done();
             });
@@ -187,9 +186,8 @@ describe('Endpoints', function(){
             expect(room).to.have.property('topic');
         });
         it('should return an error if the room does not exist', function(done){
-            hipchatter.get_room('non-existent room', function(err, message){
-                expect(err).to.be.true;
-                expect(message).to.equal('Room not found');
+            hipchatter.get_room('non-existent room', function(err){
+                expect(err.message).to.equal('Room not found');
 
                 done();
             });
@@ -218,9 +216,8 @@ describe('Endpoints', function(){
             expect(history.items[0]).to.have.property('message');
         });
         it('should return an error if the room does not exist', function(done){
-            hipchatter.history('non-existent room', function(_err, msg){
-                err = _err;
-                expect(msg).to.equal('Room not found');
+            hipchatter.history('non-existent room', function(err){
+                expect(err.message).to.equal('Room not found');
                 done();
             });
         });
@@ -381,8 +378,7 @@ describe('Endpoints', function(){
 
         it('should throw an error if no object is passed', function(done){
             hipchatter.notify(settings.test_room, function(err, response, body){
-                expect(err).to.be.true;
-                expect(response).to.contain('options');
+                expect(err.message).to.equal('Must supply an options object to the notify function containing at least the message and the room notification token. See https://www.hipchat.com/docs/apiv2/method/send_room_notification');
                 done();
             });
         });
@@ -390,8 +386,7 @@ describe('Endpoints', function(){
         it('should throw an error if required options aren\'t passed', function(done){
 
            hipchatter.notify(settings.test_room, {message: "No Auth token"}, function(err, response){
-                expect(err).to.be.true;
-                expect(response).to.contain('token');
+                expect(err.message).to.equal('Message and Room Notification token are required.');
                 done();
             });
         });


### PR DESCRIPTION
Please note that I changed the error handling to how it is normally handled in Node (first callback argument to be the error, instead of true (and the second argument being the error message)).
