### PR TITLE
Implemented the remaining room and users functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ TODO
     - ~~Delete webhook~~
     - ~~Get webhook~~
     - ~~View History~~
-    - Invite user
+    - ~~Invite user~~
 - Users
     - ~~Private message user~~
     - ~~Update user~~

--- a/hipchatter.js
+++ b/hipchatter.js
@@ -62,9 +62,14 @@ Hipchatter.prototype = {
         this.request('put', 'room/'+params.room_name+'/member/'+params.user_email, callback);
     },
     // Delete a member from a room
-    // https://www.hipchat.com/docs/apiv2/method/add_member
+    // https://www.hipchat.com/docs/apiv2/method/remove_member
     delete_member: function(params, callback) {
         this.request('delete', 'room/'+params.room_name+'/member/'+params.user_email, callback);
+    },
+    // Invite a user to a room.
+    // https://www.hipchat.com/docs/apiv2/method/invite_member
+    invite_member: function(params, reason, callback) {
+        this.request('post', 'room/'+params.room_name+'/invite/'+params.user_email, reason, callback);
     },
     // Get history from room
     // Takes either a room id or room name as a parameter

--- a/test/test.js
+++ b/test/test.js
@@ -386,6 +386,32 @@ describe('Endpoints', function(){
         
     });
 
+    // Add a member to a room
+    describe('Invite a member to a room', function() {
+        var err, response, params;
+        params = {
+            room_name: settings.test_room, 
+            user_email: 'testuser@testuser.com'
+        };
+
+        before(function(done) {
+            hipchatter.invite_member(params, {reason: 'We wanted to invite you to this room'}, function(_err, _body, _response) {
+                err = _err;
+                response = _response;
+                done();
+            });
+        });
+
+        it('should not return an error', function() {
+            expect(err).to.be.null;
+        });
+
+        it('should return status code 204 when the user is succesfully invited to the room', function() {
+            expect(response).to.equal(204);
+        });
+        
+    });
+
      // Remove a member from a room
     describe('Remove a member from a room', function() {
         var err, response, params;


### PR DESCRIPTION
Note that deleting a user works as checked in the webconsole on https://[domain].hipchat.com/people but in the test i get the wrong status code with the error: 
{
error: {
    code: 400
    message: "Can only remove participants to private rooms"
    type: "Bad Request"
}
}
I don't know if this is an API error or that maybe i'm missing something.
