### PR TITLE
set charset=utf-8 to json request

### DIFF
--- a/hipchatter.js
+++ b/hipchatter.js
@@ -344,11 +344,11 @@ Hipchatter.prototype = {
         } else if (type.toLowerCase() === 'post') {
             var url = payload.hasOwnProperty('token') ? this.url(path, payload.token) : this.url(path);
 
-            needle.post(url, payload, {json: true}, requestCallback);
+            needle.post(url, payload, {json: true, headers:{'Content-Type': 'application/json; charset=utf-8'}}, requestCallback);
 
         // PUT request 
         } else if (type.toLowerCase() === 'put') {
-            needle.put(this.url(path), payload, {json: true}, requestCallback);
+            needle.put(this.url(path), payload, {json: true, headers:{'Content-Type': 'application/json; charset=utf-8'}}, requestCallback);
 
         // DELETE request 
         } else if (type.toLowerCase() === 'delete') {


### PR DESCRIPTION
Characters will be garbled if the JSON request containing a multi-byte character. 
It is for a hipchat server to misunderstand the character code of a request.

'Content-Type: application/json' -> charset default(US-ASCII)
'Content-TYpe: application/json; charset=utf-8' -> charset UTF-8

For example, if a multi-byte character is called by hipchatter, a hipchat server will receive an unjust demand.

`json:true` and please set a `Content-Type: application/json; charset=utf-8`.
