### PR TITLE
clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ hipchatter.create_webhook('Hipchatter Room',
     {
         url: 'http://yourdomain.com',
         event: 'room_message'
-    }, function(err){
-        if (err == null) console.log('Successfully created webhook.');
+    }, function(err, webhook){
+        if (err == null) console.log('Successfully created webhook id:'+webhook.id+'.');
 });
 ````
 


### PR DESCRIPTION
The **delete_webhook** method mentions the webhook id from the **create_webhook** method, but it wasn't obvious where that was returned.
