### PR TITLE
All an optional API params object to hipchatter.users

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,30 @@ hipchatter.history('Hipchatter Room', function(err, history){
 });
 ````
 
+### hipchatter.users
+Returns all of the users.
+
+**Parameters:**
+
+- `param` (object) - Optional. query string parameters (optional)
+    - `'start-index': <int>` - Optional. The start index for the result set. Defaults to `0`.
+    - `'max-results': <int>` - Optional. The maximum number of results. Defaults to `100`.
+    - `'include-guests': <boolean>` - Optional. Include active guest users in response. Otherwise, no guest users will be included. Defaults to `'false'`.
+    - `'include-deleted': <boolean>` - Optional. Include deleted users in response. Defaults to`'false'`.
+
+**Results:** `err`, response (array: list of users)
+#### Usage
+````javascript
+// default: returns array of all emoticons
+hipchatter.users(function(err, users){
+    console.log(users);
+});
+
+hipchatter.emoticons({'start-index': 20, 'max-results': 40}, function(err, users){
+   console.log(users);
+});
+````
+
 ### hipchatter.emoticons
 Returns up to 100 emoticons.
 > [HipChat API reference](https://www.hipchat.com/docs/apiv2/method/get_all_emoticons)
@@ -344,7 +368,7 @@ How to Test
 -----------
 - Clone this repo
 - Copy `/test/settings.example.json` to `/test/settings.json`
-- Fill out your creds
+- Fill out your creds and strip comments from the JSON
 - `npm install`
 - `grunt stub` which creates the test room and test user
 - `npm test`

--- a/hipchatter.js
+++ b/hipchatter.js
@@ -3,7 +3,7 @@ var needle = require('needle');
 var async = require('async');
 
 //  Hipchatter constructor
-var Hipchatter = function(token, api_root) {  
+var Hipchatter = function(token, api_root) {
     this.token = token;
     this.api_root = api_root || 'https://api.hipchat.com/v2/';
 }
@@ -77,10 +77,14 @@ Hipchatter.prototype = {
     },
     // Get all users
     // https://www.hipchat.com/docs/apiv2/method/get_all_users
-    users: function(callback) {
-        this.request('get', 'user', function(err, results) {
+    users: function(params, callback) {
+        if (this.isFunction(params)) { // No payload
+            callback = params;
+            params = {};
+        }
+        this.request('get', 'user', params, function(err, results) {
             if(err) callback(err);
-            else callback(err, results.items)
+            else callback(err, results.items);
         });
     },
 
@@ -98,7 +102,7 @@ Hipchatter.prototype = {
     // https://www.hipchat.com/docs/apiv2/method/create_user
     create_user: function(params, callback) {
         this.request('post', 'user', params, callback);
-    },    
+    },
     // Deletes a user
     // https://www.hipchat.com/docs/apiv2/method/delete_user
     delete_user: function(user, callback) {
@@ -120,7 +124,7 @@ Hipchatter.prototype = {
     // }
     //
     // or
-    // 
+    //
     // Get emoticon by shortcut or id
     // https://www.hipchat.com/docs/apiv2/method/get_emoticon
     //
@@ -230,7 +234,7 @@ Hipchatter.prototype = {
         var self = this;
         this.webhooks(room, function(err, response){
             if (err) return callback(new Error(response));
-            
+
             var hooks = response.items;
             var hookCalls = [];
             for (var i=0; i<hooks.length; i++){
@@ -260,7 +264,7 @@ Hipchatter.prototype = {
             else if (err.message == 'Room not found'){
                 return callback(null, false);
             }
-            else { 
+            else {
                 console.log(err)
                 return callback(err)
             }
@@ -307,9 +311,9 @@ Hipchatter.prototype = {
 
     // Make a request
     // type: required - type of REST request ('get' or 'post' currently)
-    // path: required - 
-    // payload: optional - query string data for 'get', '' 
-    // callback: required -      
+    // path: required -
+    // payload: optional - query string data for 'get', ''
+    // callback: required -
     request: function(type, path, payload, callback){
         if (this.isFunction(payload)) { // No payload
             callback = payload;
@@ -337,7 +341,6 @@ Hipchatter.prototype = {
         // GET request
         if (type.toLowerCase() === 'get') {
             var url = payload.hasOwnProperty('token') ? this.url(path, payload, payload.token) : this.url(path, payload);
-
             needle.get(url, requestCallback);
 
         // POST request
@@ -346,16 +349,16 @@ Hipchatter.prototype = {
 
             needle.post(url, payload, {json: true, headers:{'Content-Type': 'application/json; charset=utf-8'}}, requestCallback);
 
-        // PUT request 
+        // PUT request
         } else if (type.toLowerCase() === 'put') {
             needle.put(this.url(path), payload, {json: true, headers:{'Content-Type': 'application/json; charset=utf-8'}}, requestCallback);
 
-        // DELETE request 
+        // DELETE request
         } else if (type.toLowerCase() === 'delete') {
             needle.delete(this.url(path), {}, requestCallback);
 
-        // otherwise, something went wrong   
-        } else { 
+        // otherwise, something went wrong
+        } else {
             callback(new Error('Invalid use of the hipchatter.request function.'));
         }
     },

--- a/test/users.js
+++ b/test/users.js
@@ -4,7 +4,7 @@ var expect = chai.expect;
 var colors = require("colors");
 
 // Make sure the API Credentials are present
-try { var settings = require(__dirname+"/settings.json"); } 
+try { var settings = require(__dirname+"/settings.json"); }
 catch (e) { console.error('Create test/settings.json and populate with your credentials.'.red);}
 
 // Setup hipchatter
@@ -21,6 +21,32 @@ describe('Users', function() {
         // Make the request
         before(function(done){
             hipchatter.users(function(_err, _users){
+                err = _err;
+                users = _users;
+                done();
+            });
+        });
+        it('should not return an error', function(){
+            expect(err).to.be.null;
+        });
+        it('should return a list of users', function(){
+            expect(users).to.be.ok;
+            expect(users).to.not.be.empty;
+        });
+        it('should return users that have an id and name, at least', function(){
+            expect(users[0]).to.have.property('name');
+            expect(users[0]).to.have.property('id');
+        });
+    });
+
+    // Get all users
+    describe('Get All Users with Options', function() {
+        // Set scope for the responses
+        var err, users;
+
+        // Make the request
+        before(function(done){
+            hipchatter.users({"max-results": 1000}, function(_err, _users){
                 err = _err;
                 users = _users;
                 done();
@@ -77,7 +103,7 @@ describe('Users', function() {
             expect(user).to.have.property('title');
             expect(user).to.have.property('name');
         });
-        
+
     });
 
     // Update user
@@ -107,7 +133,7 @@ describe('Users', function() {
             expect(response).to.equal(204);
         });
 
-        //TODO check with get_user that the user was actually updated        
+        //TODO check with get_user that the user was actually updated
     });
 
     //PM User
@@ -129,7 +155,7 @@ describe('Users', function() {
         it('should return status code 204 when the private message is succesfully send', function() {
             expect(response).to.equal(204);
         });
-        
+
     });
 
     //Deleting a user works, but i don't get the correct response code, API bug or am i missing something.
@@ -153,5 +179,5 @@ describe('Users', function() {
 
     });
 
-    
+
 });


### PR DESCRIPTION
Currently `hipchatter.users` only returns the first 100 users. This PR adds params as an optional first argument, so that using `max-results` gets me the first 1000 users, which is more than enough for my current use case.