### PR TITLE
Readd compatibility with node version 0.12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "main": "hipchatter.js",
   "dependencies": {
-    "needle": "~0.6.3",
+    "needle": "^0.10.0",
     "async": "~0.2.9"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hipchatter",
   "description": "Wrapper for the HipChat API (v2)",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Charlton Roberts <charltonroberts@gmail.com (http://charlton.io)",
   "contributors": [
     "Macklin Underdown <macklinu@gmail.com> (http://mackli.nu)"


### PR DESCRIPTION
Hi there,

Version 0.6.x of needle (which is currently configured as a dependency) requires qs as a dependency. Since 3rd of november qs is only supporting node > 4 e.g. by using ES6. Newer versions of needle do not require qs which enables hipchatter to also work with node 0.12.x.

Therefore I have raised the needle dependency version to 0.10.0.