### PR TITLE
use .match instead of == for testing for 'Room not found'

### DIFF
--- a/hipchatter.js
+++ b/hipchatter.js
@@ -261,7 +261,7 @@ Hipchatter.prototype = {
             if(err === null){
                 return callback(null, true);
             }
-            else if (err.message == 'Room not found'){
+            else if (err.message.match(/Room .* not found/)){
                 return callback(null, false);
             }
             else {


### PR DESCRIPTION
HipChat API now returns the name of the room in the not found message: "Room <room.name>  not found"