### PR TITLE
update needle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hipchatter",
   "description": "Wrapper for the HipChat API (v2)",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Charlton Roberts <charltonroberts@gmail.com (http://charlton.io)",
   "contributors": [
     "Macklin Underdown <macklinu@gmail.com> (http://mackli.nu)"

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "main": "hipchatter.js",
   "dependencies": {
-    "needle": "~0.6.3",
-    "async": "~0.2.9"
+    "async": "~0.2.9",
+    "needle": "^1.0.0"
   },
   "engines": {
     "node": "*"


### PR DESCRIPTION
This upgrades the needle dependency.

The motivation for this is that needle-0.6.3 has an unversioned dependency on qs. This triggers [a bug in npm](https://github.com/npm/npm/issues/11493) which can break projects using hipchatter.

Fixes #24