### PR TITLE
Don't escape REST path

### DIFF
--- a/hipchatter.js
+++ b/hipchatter.js
@@ -276,7 +276,7 @@ Hipchatter.prototype = {
     // Generator API url
     url: function(rest_path, query, alternate_token){
         // inner helpers
-        var BASE_URL = this.api_root + escape(rest_path) + '?auth_token=';
+        var BASE_URL = this.api_root + rest_path + '?auth_token=';
         var queryString = function(query) {
             var query_string = '';
             for (var key in query) {


### PR DESCRIPTION
If you escape the REST path, the % signs are re-escaped when the request is actually made with `needle`.

For example `needle.post(escape("api.hipchat.com/v2/room/test room"))` will result in the incorrect path `/v2/room/test%2520room` where the space character has been replaced with `%2520` instead of `%20`. Conversely, it can be seen that omitting the `escape` call and allowing `needle` to do the escaping for us as `needle.post("api.hipchat.com/v2/room/test room")` yields the correct result `/v2/room/test%20room`.
