### PR TITLE
removed needle and async dependencies.

### DIFF
--- a/hipchatter.js
+++ b/hipchatter.js
@@ -389,6 +389,15 @@ Hipchatter.prototype = {
         var requestCallback = function (error, response, body) {
             if (DEBUG) {console.log('RESPONSE: ', error, response, body);}
 
+            //parse JSON if needed
+            if (response.headers["content-type"]==="application/json") {
+                try {
+                    body = JSON.parse(body);
+                } catch(err) {
+                    error = "Content-Type is JSON, but could not parse: " + err
+                }
+            }
+
             // Connection error
             if (!!error) callback(new Error('HipChat API Error.' + error));
 

--- a/hipchatter.js
+++ b/hipchatter.js
@@ -224,9 +224,9 @@ Hipchatter.prototype = {
         this.request('get', 'room/'+room+'/webhook', callback);
     },
     delete_webhook: function(room, id, callback){
-        this.request("delete", this.buildURL('room/'+room+'/webhook/'+id), function (error, response, body) {
+        this.request("delete", 'room/'+room+'/webhook/'+id, function (error, response, body) {
             // Connection error
-            if (!!error) callback(new Error('HipChat API Error.'));
+            if (!!error) callback(new Error('HipChat API Error: ' + error));
 
             // HipChat returned an error or no HTTP Success status code
             else if (body.hasOwnProperty('error') || response.statusCode < 200 || response.statusCode >= 300){

--- a/package.json
+++ b/package.json
@@ -21,10 +21,6 @@
     "url": "https://github.com/charltoons/hipchatter.git"
   },
   "main": "hipchatter.js",
-  "dependencies": {
-    "async": "~0.2.9",
-    "needle": "^1.0.0"
-  },
   "engines": {
     "node": "*"
   },


### PR DESCRIPTION
While cleaning up outdated dependencies on one my my projects, I noticed that this is pulling down some pretty old versions of `needle` and `async`. 

`async` was only used in one place and was easily replaced with the built-in ES6 Promises (i.e. `Promise.all(...).then(callback).

`needle` is nice, but its really not needed for this limited use case so I rewrote `this.request` to just use Node's `https` library.

Since this project isn't updated often I thought it would be good to not rely on 3rd party libraries.